### PR TITLE
conducting Find & Replace on 'Seperator' and 'Separator' spelling change

### DIFF
--- a/dist/es6/controller.js
+++ b/dist/es6/controller.js
@@ -16,7 +16,7 @@ var uniq = _.uniq;
 var values = _.values;
 
 function ensureActionIsDefined(actionMap) {
-  if (!isFunction(this[actionMap.method])) throw new Error(`${this.className} action "${actionMap.name}${this.eventSeperator}${actionMap.method}" method is undefined`);
+  if (!isFunction(this[actionMap.method])) throw new Error(`${this.className} action "${actionMap.name}${this.eventSeparator}${actionMap.method}" method is undefined`);
 }
 
 function mapAction(action) {
@@ -38,7 +38,7 @@ function registerActions(dispatcher) {
 function setControllerDefaults() {
   this.name = this.name || "Anonymous";
   defaults(this, {
-    eventSeperator: ":",
+    eventSeparator: ":",
     actions: [],
     channel: "controller",
     className: `${s.constantize(this.name)}Controller`,
@@ -63,7 +63,7 @@ class Controller {
   initialize() {}
   all() {}
   actionEventName(action) {
-    return compact([this.namespace, this.channel, this.controllerEventName, action]).join(this.eventSeperator);
+    return compact([this.namespace, this.channel, this.controllerEventName, action]).join(this.eventSeparator);
   }
 }
 

--- a/dist/jskit.js
+++ b/dist/jskit.js
@@ -10979,7 +10979,7 @@ var uniq = _.uniq;
 var values = _.values;
 function ensureActionIsDefined(actionMap) {
   if (!isFunction(this[actionMap.method]))
-    throw new Error((this.className + " action \"" + actionMap.name + this.eventSeperator + actionMap.method + "\" method is undefined"));
+    throw new Error((this.className + " action \"" + actionMap.name + this.eventSeparator + actionMap.method + "\" method is undefined"));
 }
 function mapAction(action) {
   var isMappedAction = isObject(action);
@@ -11001,7 +11001,7 @@ function registerActions(dispatcher) {
 function setControllerDefaults() {
   this.name = this.name || "Anonymous";
   defaults(this, {
-    eventSeperator: ":",
+    eventSeparator: ":",
     actions: [],
     channel: "controller",
     className: (s.constantize(this.name) + "Controller"),
@@ -11023,7 +11023,7 @@ var Controller = function Controller(dispatcher, attrs) {
   initialize: function() {},
   all: function() {},
   actionEventName: function(action) {
-    return compact([this.namespace, this.channel, this.controllerEventName, action]).join(this.eventSeperator);
+    return compact([this.namespace, this.channel, this.controllerEventName, action]).join(this.eventSeparator);
   }
 }, {});
 var $__default = Controller;

--- a/dist/jskit_legacy.js
+++ b/dist/jskit_legacy.js
@@ -51,7 +51,7 @@ var uniq = _.uniq;
 var values = _.values;
 
 function ensureActionIsDefined(actionMap) {
-  if (!isFunction(this[actionMap.method])) throw new Error(this.className + " action \"" + actionMap.name + this.eventSeperator + actionMap.method + "\" method is undefined");
+  if (!isFunction(this[actionMap.method])) throw new Error(this.className + " action \"" + actionMap.name + this.eventSeparator + actionMap.method + "\" method is undefined");
 }
 
 function mapAction(action) {
@@ -73,7 +73,7 @@ function registerActions(dispatcher) {
 function setControllerDefaults() {
   this.name = this.name || "Anonymous";
   defaults(this, {
-    eventSeperator: ":",
+    eventSeparator: ":",
     actions: [],
     channel: "controller",
     className: s.constantize(this.name) + "Controller",
@@ -98,7 +98,7 @@ Controller.prototype.initialize = function() {};
 Controller.prototype.all = function() {};
 
 Controller.prototype.actionEventName = function(action) {
-  return compact([this.namespace, this.channel, this.controllerEventName, action]).join(this.eventSeperator);
+  return compact([this.namespace, this.channel, this.controllerEventName, action]).join(this.eventSeparator);
 };
 
 module.exports = Controller;

--- a/dist/jskit_standalone.js
+++ b/dist/jskit_standalone.js
@@ -8535,7 +8535,7 @@ var uniq = _.uniq;
 var values = _.values;
 function ensureActionIsDefined(actionMap) {
   if (!isFunction(this[actionMap.method]))
-    throw new Error((this.className + " action \"" + actionMap.name + this.eventSeperator + actionMap.method + "\" method is undefined"));
+    throw new Error((this.className + " action \"" + actionMap.name + this.eventSeparator + actionMap.method + "\" method is undefined"));
 }
 function mapAction(action) {
   var isMappedAction = isObject(action);
@@ -8557,7 +8557,7 @@ function registerActions(dispatcher) {
 function setControllerDefaults() {
   this.name = this.name || "Anonymous";
   defaults(this, {
-    eventSeperator: ":",
+    eventSeparator: ":",
     actions: [],
     channel: "controller",
     className: (s.constantize(this.name) + "Controller"),
@@ -8579,7 +8579,7 @@ var Controller = function Controller(dispatcher, attrs) {
   initialize: function() {},
   all: function() {},
   actionEventName: function(action) {
-    return compact([this.namespace, this.channel, this.controllerEventName, action]).join(this.eventSeperator);
+    return compact([this.namespace, this.channel, this.controllerEventName, action]).join(this.eventSeparator);
   }
 }, {});
 var $__default = Controller;

--- a/example/jskit.js
+++ b/example/jskit.js
@@ -10979,7 +10979,7 @@ var uniq = _.uniq;
 var values = _.values;
 function ensureActionIsDefined(actionMap) {
   if (!isFunction(this[actionMap.method]))
-    throw new Error((this.className + " action \"" + actionMap.name + this.eventSeperator + actionMap.method + "\" method is undefined"));
+    throw new Error((this.className + " action \"" + actionMap.name + this.eventSeparator + actionMap.method + "\" method is undefined"));
 }
 function mapAction(action) {
   var isMappedAction = isObject(action);
@@ -11001,7 +11001,7 @@ function registerActions(dispatcher) {
 function setControllerDefaults() {
   this.name = this.name || "Anonymous";
   defaults(this, {
-    eventSeperator: ":",
+    eventSeparator: ":",
     actions: [],
     channel: "controller",
     className: (s.constantize(this.name) + "Controller"),
@@ -11023,7 +11023,7 @@ var Controller = function Controller(dispatcher, attrs) {
   initialize: function() {},
   all: function() {},
   actionEventName: function(action) {
-    return compact([this.namespace, this.channel, this.controllerEventName, action]).join(this.eventSeperator);
+    return compact([this.namespace, this.channel, this.controllerEventName, action]).join(this.eventSeparator);
   }
 }, {});
 var $__default = Controller;

--- a/example/jskit_legacy.js
+++ b/example/jskit_legacy.js
@@ -51,7 +51,7 @@ var uniq = _.uniq;
 var values = _.values;
 
 function ensureActionIsDefined(actionMap) {
-  if (!isFunction(this[actionMap.method])) throw new Error(this.className + " action \"" + actionMap.name + this.eventSeperator + actionMap.method + "\" method is undefined");
+  if (!isFunction(this[actionMap.method])) throw new Error(this.className + " action \"" + actionMap.name + this.eventSeparator + actionMap.method + "\" method is undefined");
 }
 
 function mapAction(action) {
@@ -73,7 +73,7 @@ function registerActions(dispatcher) {
 function setControllerDefaults() {
   this.name = this.name || "Anonymous";
   defaults(this, {
-    eventSeperator: ":",
+    eventSeparator: ":",
     actions: [],
     channel: "controller",
     className: s.constantize(this.name) + "Controller",
@@ -98,7 +98,7 @@ Controller.prototype.initialize = function() {};
 Controller.prototype.all = function() {};
 
 Controller.prototype.actionEventName = function(action) {
-  return compact([this.namespace, this.channel, this.controllerEventName, action]).join(this.eventSeperator);
+  return compact([this.namespace, this.channel, this.controllerEventName, action]).join(this.eventSeparator);
 };
 
 module.exports = Controller;

--- a/example/jskit_standalone.js
+++ b/example/jskit_standalone.js
@@ -8535,7 +8535,7 @@ var uniq = _.uniq;
 var values = _.values;
 function ensureActionIsDefined(actionMap) {
   if (!isFunction(this[actionMap.method]))
-    throw new Error((this.className + " action \"" + actionMap.name + this.eventSeperator + actionMap.method + "\" method is undefined"));
+    throw new Error((this.className + " action \"" + actionMap.name + this.eventSeparator + actionMap.method + "\" method is undefined"));
 }
 function mapAction(action) {
   var isMappedAction = isObject(action);
@@ -8557,7 +8557,7 @@ function registerActions(dispatcher) {
 function setControllerDefaults() {
   this.name = this.name || "Anonymous";
   defaults(this, {
-    eventSeperator: ":",
+    eventSeparator: ":",
     actions: [],
     channel: "controller",
     className: (s.constantize(this.name) + "Controller"),
@@ -8579,7 +8579,7 @@ var Controller = function Controller(dispatcher, attrs) {
   initialize: function() {},
   all: function() {},
   actionEventName: function(action) {
-    return compact([this.namespace, this.channel, this.controllerEventName, action]).join(this.eventSeperator);
+    return compact([this.namespace, this.channel, this.controllerEventName, action]).join(this.eventSeparator);
   }
 }, {});
 var $__default = Controller;

--- a/lib/controller.js
+++ b/lib/controller.js
@@ -16,7 +16,7 @@ var uniq = _.uniq;
 var values = _.values;
 
 function ensureActionIsDefined(actionMap) {
-  if (!isFunction(this[actionMap.method])) throw new Error(`${this.className} action "${actionMap.name}${this.eventSeperator}${actionMap.method}" method is undefined`);
+  if (!isFunction(this[actionMap.method])) throw new Error(`${this.className} action "${actionMap.name}${this.eventSeparator}${actionMap.method}" method is undefined`);
 }
 
 function mapAction(action) {
@@ -38,7 +38,7 @@ function registerActions(dispatcher) {
 function setControllerDefaults() {
   this.name = this.name || "Anonymous";
   defaults(this, {
-    eventSeperator: ":",
+    eventSeparator: ":",
     actions: [],
     channel: "controller",
     className: `${s.constantize(this.name)}Controller`,
@@ -63,7 +63,7 @@ class Controller {
   initialize() {}
   all() {}
   actionEventName(action) {
-    return compact([this.namespace, this.channel, this.controllerEventName, action]).join(this.eventSeperator);
+    return compact([this.namespace, this.channel, this.controllerEventName, action]).join(this.eventSeparator);
   }
 }
 

--- a/lib/legacy/controller.js
+++ b/lib/legacy/controller.js
@@ -15,7 +15,7 @@ var uniq = _.uniq;
 var values = _.values;
 
 function ensureActionIsDefined(actionMap) {
-  if (!isFunction(this[actionMap.method])) throw new Error(this.className + " action \"" + actionMap.name + this.eventSeperator + actionMap.method + "\" method is undefined");
+  if (!isFunction(this[actionMap.method])) throw new Error(this.className + " action \"" + actionMap.name + this.eventSeparator + actionMap.method + "\" method is undefined");
 }
 
 function mapAction(action) {
@@ -37,7 +37,7 @@ function registerActions(dispatcher) {
 function setControllerDefaults() {
   this.name = this.name || "Anonymous";
   defaults(this, {
-    eventSeperator: ":",
+    eventSeparator: ":",
     actions: [],
     channel: "controller",
     className: s.constantize(this.name) + "Controller",
@@ -62,7 +62,7 @@ Controller.prototype.initialize = function() {};
 Controller.prototype.all = function() {};
 
 Controller.prototype.actionEventName = function(action) {
-  return compact([this.namespace, this.channel, this.controllerEventName, action]).join(this.eventSeperator);
+  return compact([this.namespace, this.channel, this.controllerEventName, action]).join(this.eventSeparator);
 };
 
 module.exports = Controller;

--- a/spec/controller_spec.js
+++ b/spec/controller_spec.js
@@ -71,8 +71,8 @@ describe("Controller", function() {
     expect(dispatcher.hasAction(subject, { mapped: "action" })).to.equal(true);
   });
 
-  it("has an eventSeperator", () => {
-    expect(subject.eventSeperator).to.equal(":");
+  it("has an eventSeparator", () => {
+    expect(subject.eventSeparator).to.equal(":");
   });
 
   it("has a default all function", () => {
@@ -93,7 +93,7 @@ describe("Controller", function() {
         subject.channel,
         subject.controllerEventName,
         "foo"
-      ]).join(subject.eventSeperator);
+      ]).join(subject.eventSeparator);
 
       expect(subject.actionEventName("foo")).to.equal(expectedEventName);
     });
@@ -163,12 +163,12 @@ describe("Controller", function() {
     });
   });
 
-  describe("with eventSeperator", () => {
+  describe("with eventSeparator", () => {
     beforeEach(() => {
-      subject = createController(dispatcher, controllerAttributes({ eventSeperator: "." }));
+      subject = createController(dispatcher, controllerAttributes({ eventSeparator: "." }));
     });
 
-    it("wires up the actions with the eventSeperator", () => {
+    it("wires up the actions with the eventSeparator", () => {
       dispatcher.trigger(subject.actionEventName("index"));
       expect(subject.index.called).to.equal(true);
     });

--- a/spec/legacy/controller_spec.js
+++ b/spec/legacy/controller_spec.js
@@ -68,8 +68,8 @@ describe("Controller", function() {
     expect(dispatcher.hasAction(subject, { mapped: "action" })).to.equal(true);
   });
 
-  it("has an eventSeperator", function() {
-    expect(subject.eventSeperator).to.equal(":");
+  it("has an eventSeparator", function() {
+    expect(subject.eventSeparator).to.equal(":");
   });
 
   it("has a default all function", function() {
@@ -90,7 +90,7 @@ describe("Controller", function() {
         subject.channel,
         subject.controllerEventName,
         "foo"
-      ]).join(subject.eventSeperator);
+      ]).join(subject.eventSeparator);
 
       expect(subject.actionEventName("foo")).to.equal(expectedEventName);
     });
@@ -160,12 +160,12 @@ describe("Controller", function() {
     });
   });
 
-  describe("with eventSeperator", function() {
+  describe("with eventSeparator", function() {
     beforeEach(function() {
-      subject = createController(dispatcher, controllerAttributes({ eventSeperator: "." }));
+      subject = createController(dispatcher, controllerAttributes({ eventSeparator: "." }));
     });
 
-    it("wires up the actions with the eventSeperator", function() {
+    it("wires up the actions with the eventSeparator", function() {
       dispatcher.trigger(subject.actionEventName("index"));
       expect(subject.index.called).to.equal(true);
     });


### PR DESCRIPTION
@daytonn Did a quick find and replace on the JSKit files for the `seperator` misspellings. I did notice that some of the npm modules likewise use the `seper` spelling, so you might have been following that convention for that reason.

All tests pass after the changes within.

If you decide not to make this switch, just close and I'll change back the README syntax changes, as well.
